### PR TITLE
apply changes for ruby-2.1.3 in heroku

### DIFF
--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -14,7 +14,8 @@ Encoding.default_external = Encoding::UTF_8 if defined?(Encoding)
 class LanguagePack::Base
   include LanguagePack::ShellHelpers
 
-  VENDOR_URL = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby"
+  VENDOR_URL = ENV['BUILD_PACK_VENDOR_URL'] || "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby"
+  DEFAULT_LEGACY_STACK = "cedar"
 
   attr_reader :build_path, :cache
 

--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -16,8 +16,11 @@ module LanguagePack
       run!(curl)
     end
 
-    def fetch_untar(path)
+    def fetch_untar(path, options={})
       curl = curl_command("#{@host_url.join(path)} -s -o")
+      if options[:prefix_node]
+        curl = curl_command("#{@host_url.join(options[:prefix_node],path)} -s -o")
+      end
       run!("#{curl} - | tar zxf -")
     end
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -297,7 +297,11 @@ ERROR_MSG
             FileUtils.rm(file)
             FileUtils.rm(sha_file)
           else
-            @fetchers[:buildpack].fetch_untar("#{ruby_version.version}.tgz")
+            if ruby_version.version == "ruby-2.1.3"
+              @fetchers[:buildpack].fetch_untar("#{ruby_version.version}.tgz", :prefix_node=>LanguagePack::Base::DEFAULT_LEGACY_STACK)
+            else
+              @fetchers[:buildpack].fetch_untar("#{ruby_version.version}.tgz")
+            end
           end
         end
       end


### PR DESCRIPTION
the buildpacks has been change to new path.
https://github.com/heroku/heroku-buildpack-ruby/issues/304

so response the changes, make cedar as prefix_node in deployment in ruby 2.1.3
